### PR TITLE
Fix mkdir script

### DIFF
--- a/install-font.sh
+++ b/install-font.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Start install"
-sudo mkdir /usr/share/fonts/truetype/custom
+sudo mkdir -p /usr/share/fonts/truetype/custom
 echo "Downloading font"
 wget -c https://github.com/cstrap/monaco-font/raw/master/Monaco_Linux.ttf
 echo "Installing font"


### PR DESCRIPTION
Fix bug that installatoin would fail if there's no directory '/usr/share/fonts/truetype/custom'
